### PR TITLE
feat(kno-4403): add support for dynamic TTLs

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-erlang 25.1
-elixir 1.14.3
+erlang 25.3.2
+elixir 1.14.5-otp-25

--- a/lib/plug.ex
+++ b/lib/plug.ex
@@ -306,16 +306,15 @@ defmodule OneAndDone.Plug do
     end
   end
 
-  @doc false
-  def build_ttl(conn, idempotency_key, %{build_ttl_fn: build_ttl_fn} = opts)
-      when is_function(build_ttl_fn, 2) do
+  defp build_ttl(conn, idempotency_key, %{build_ttl_fn: build_ttl_fn} = opts)
+       when is_function(build_ttl_fn, 2) do
     case build_ttl_fn.(conn, idempotency_key) do
       ttl when is_integer(ttl) -> ttl
       _ -> opts.ttl
     end
   end
 
-  def build_ttl(_, _, opts), do: opts.ttl
+  defp build_ttl(_, _, opts), do: opts.ttl
 
   defp handle_request_mismatch(conn, response, idempotency_key) do
     Telemetry.event(

--- a/lib/plug.ex
+++ b/lib/plug.ex
@@ -25,6 +25,16 @@ defmodule OneAndDone.Plug do
           # Optional: How long to keep entries, defaults to 86_400 (24 hours)
           ttl: 86_400,
 
+          # Optional: Function reference to generate an idempotence TTL per request.
+          # Takes the current `Plug.Conn` as the first argument and the current
+          # `idempotency_key` as the second.
+          #
+          # When provided, this function is called before falling back to the
+          # `ttl` option.
+          #
+          # Defaults to `nil`.
+          build_ttl_fn: &OneAndDone.Plug.build_ttl/2,
+
           # Optional: Which methods to cache, defaults to ["POST", "PUT"]
           # Used by the default idempotency_key_fn to quickly determine if the request
           # can be cached. If you override idempotency_key_fn, consider checking the
@@ -160,6 +170,7 @@ defmodule OneAndDone.Plug do
   @spec init(cache: OneAndDone.Cache.t()) :: %{
           cache: any,
           ttl: any,
+          build_ttl_fn: any,
           supported_methods: any,
           ignored_response_headers: any,
           idempotency_key_fn: any,
@@ -172,6 +183,7 @@ defmodule OneAndDone.Plug do
     %{
       cache: Keyword.get(opts, :cache) || raise(OneAndDone.Errors.CacheMissingError),
       ttl: Keyword.get(opts, :ttl, @ttl),
+      build_ttl_fn: Keyword.get(opts, :build_ttl_fn),
       supported_methods: Keyword.get(opts, :supported_methods, @supported_methods),
       ignored_response_headers: Keyword.get(opts, :ignored_response_headers, ["x-request-id"]),
       idempotency_key_fn:
@@ -282,16 +294,28 @@ defmodule OneAndDone.Plug do
         %{idempotency_key: idempotency_key, conn: conn},
         fn ->
           response = Parser.build_response(conn)
+          ttl = build_ttl(conn, idempotency_key, opts)
 
           conn
           |> opts.cache_key_fn.(idempotency_key)
-          |> opts.cache.put({:ok, response}, ttl: opts.ttl)
+          |> opts.cache.put({:ok, response}, ttl: ttl)
 
           conn
         end
       )
     end
   end
+
+  @doc false
+  def build_ttl(conn, idempotency_key, %{build_ttl_fn: build_ttl_fn} = opts)
+      when is_function(build_ttl_fn, 2) do
+    case build_ttl_fn.(conn, idempotency_key) do
+      ttl when is_integer(ttl) -> ttl
+      _ -> opts.ttl
+    end
+  end
+
+  def build_ttl(_, _, opts), do: opts.ttl
 
   defp handle_request_mismatch(conn, response, idempotency_key) do
     Telemetry.event(


### PR DESCRIPTION
The new `:build_ttl_fn` option will allow callers to customize the idempotency cache TTL on a per-request basis. When provided, OneAndDone will first call the provided function to generate a TTL. If that call returns anything other than an integer, the plug falls back to the statically configured TTL via the `:ttl` option, and then finally the default of 24 hours.